### PR TITLE
Remove alias for release channel

### DIFF
--- a/src/commands/publish.js
+++ b/src/commands/publish.js
@@ -88,7 +88,7 @@ export default (program: any) => {
     .option('-s, --send-to [dest]', 'A phone number or e-mail address to send a link to')
     .option('-c, --clear', 'Clear the React Native packager cache')
     .option(
-      '-c --release-channel <release channel>',
+      '--release-channel <release channel>',
       "The release channel to publish to. Default is 'default'.",
       'default'
     )


### PR DESCRIPTION
it can't be the same as --clear.

--- 

I'm open to change the alias, but this seems very confusing.

Fixes https://github.com/expo/expo/issues/1332