### PR TITLE
add envinfo to diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "cli-table": "^0.3.1",
     "commander": "^2.9.0",
     "delay-async": "^1.0.0",
+    "envinfo": "^3.11.1",
     "es6-error": "^3.0.0",
     "fs-extra": "^4.0.2",
     "glob": "^7.0.3",

--- a/src/commands/diagnostics.js
+++ b/src/commands/diagnostics.js
@@ -1,4 +1,5 @@
 import { Diagnostics } from 'xdl';
+import { print as envinfoPrint } from 'envinfo';
 
 import simpleSpinner from '@expo/simple-spinner';
 
@@ -11,6 +12,8 @@ async function action(options) {
     uploadLogs: true,
   });
   simpleSpinner.stop();
+
+  envinfoPrint();
 
   log(`Please share this URL with the Expo team: ${url}.`);
   log('You can join our slack here: https://slack.expo.io/.');

--- a/src/commands/diagnostics.js
+++ b/src/commands/diagnostics.js
@@ -7,6 +7,8 @@ import log from '../log';
 
 async function action(options) {
   log('Generating diagnostics report...');
+  log('You can join our slack here: https://slack.expo.io/.');
+
   simpleSpinner.start();
   let { url } = await Diagnostics.getDeviceInfoAsync({
     uploadLogs: true,
@@ -15,8 +17,7 @@ async function action(options) {
 
   envinfoPrint();
 
-  log(`Please share this URL with the Expo team: ${url}.`);
-  log('You can join our slack here: https://slack.expo.io/.');
+  console.log(`\x1b[4mDiagnostics report:\x1b[0m\n  ${url}\n`);
   log.raw(url);
 }
 


### PR DESCRIPTION
Per this [issue](https://github.com/expo/expo/issues/1304), added basic envinfo call in diagnostics:

`exp diagnostics`

```
tabrindle-mbp:exp tabrindle$ node bin/exp.js diagnostics
[exp] Generating diagnostics report...
/
Environment:
  OS: macOS High Sierra 10.13
  Node: 8.9.4
  Yarn: 1.3.2
  npm: 5.6.0
  Watchman: 4.9.0
  Xcode: Xcode 9.0 Build version 9A235
  Android Studio: 2.3 AI-162.3934792

[exp] Please share this URL with the Expo team: https://exp-xde-diagnostics.s3.amazonaws.com/tabrindle-333f890d-3b20-4ae8-97a7-2f1501918e58.tar.gz.
[exp] You can join our slack here: https://slack.expo.io/.
```