### PR TITLE
Add timestamps to log prefix

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -1,5 +1,7 @@
 import chalk from 'chalk';
 
+const maxTimestampLength = new Date('12-31-1970 23:59:59').toLocaleTimeString().length;
+
 let _bundleProgressBar;
 
 let _printNewLineBeforeNextLog = false;
@@ -57,7 +59,7 @@ function respectProgressBars(commitLogs) {
 }
 
 function getPrefix(chalkColor) {
-  const timestamp = new Date().toLocaleTimeString().padStart(11, '0');
+  const timestamp = new Date().toLocaleTimeString().padStart(maxTimestampLength);
   const leftBracket = chalkColor('[');
   const rightBracket = chalkColor(']');
   return (

--- a/src/log.js
+++ b/src/log.js
@@ -57,7 +57,18 @@ function respectProgressBars(commitLogs) {
 }
 
 function getPrefix(chalkColor) {
-  return chalkColor('[') + chalk.gray('exp') + chalkColor(']');
+  const timestamp = new Date().toLocaleTimeString().padStart(11, '0');
+  const leftBracket = chalkColor('[');
+  const rightBracket = chalkColor(']');
+  return (
+    leftBracket +
+    chalk.gray('exp') +
+    rightBracket +
+    ' ' +
+    leftBracket +
+    chalk.gray(timestamp) +
+    rightBracket
+  );
 }
 
 function withPrefixAndTextColor(args, chalkColor = chalk.gray) {


### PR DESCRIPTION
Currently, the log entries have no temporal relationship and it can be hard to know when a rebuild was triggered or if the error you saw was from this attempt or a previous one, etc. This should alleviate that.

(Feel free to suggest an alternate format, I just picked one I thought was readable.)

Previous output:

```sh
[exp] Loading dependency graph.
[exp] Successfully ran `adb reverse`. Localhost urls should work on the connected Android device.
[exp] Dependency graph loaded.
[exp] Tunnel connected.
[exp] Expo is ready.
```

After this PR (as-is):

```sh
[exp] [11:54:08 AM] Loading dependency graph.
[exp] [11:54:08 AM] Successfully ran `adb reverse`. Localhost urls should work on the connected Android device.
[exp] [11:54:09 AM] Dependency graph loaded.
[exp] [11:54:09 AM] Tunnel connected.
[exp] [11:54:10 AM] Expo is ready.
```