### PR TITLE
Update exp start to include QR code for detached apps

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -44,11 +44,9 @@ async function action(projectDir, options) {
 
   let { exp } = await ProjectUtils.readConfigJsonAsync(projectDir);
 
-  if (!exp.isDetached) {
-    log('You can scan this QR code:');
-    log.newLine();
-    urlOpts.printQRCode(url);
-  }
+  log('You can scan this QR code:');
+  log.newLine();
+  urlOpts.printQRCode(url);
 
   log('Your URL is: ' + chalk.underline(url));
   if (isUrlFallback) {


### PR DESCRIPTION
There is no need to check if the device is detached when generating a QR code on `exp start` it works either way