### PR TITLE
Fix non-interactive doesnt work

### DIFF
--- a/src/accounts.js
+++ b/src/accounts.js
@@ -59,7 +59,7 @@ export async function loginOrRegisterIfLoggedOut() {
 
 export async function login(options: CommandOptions) {
   const user = await UserManager.getCurrentUserAsync();
-  if (!options.nonInteractive) {
+  if (!options.parent.nonInteractive) {
     if (user) {
       const question = [
         {

--- a/src/expo_commands/start.js
+++ b/src/expo_commands/start.js
@@ -58,7 +58,7 @@ async function action(projectDir, options) {
   const { exp } = await ProjectUtils.readConfigJsonAsync(projectDir);
 
   log(`Expo DevTools is running at ${chalk.underline(devToolsUrl)}`);
-  if (!options.nonInteractive && !exp.isDetached) {
+  if (!options.parent.nonInteractive && !exp.isDetached) {
     if (await UserSettings.getAsync('openDevToolsAtStartup', true)) {
       log(`Opening DevTools in the browser... (press ${chalk.bold`shift-d`} to disable)`);
       opn(devToolsUrl);


### PR DESCRIPTION
I ran login with `--non-interactive` but still showing the error if without this fix.
```
exp login -u giautm -p XXXXXXXXXXX --non-interactive
[11:58:50] Input is required, but exp is in non-interactive mode.
Required input:
> You are already logged in as giautm. Log in as new user?
```