### PR TITLE
Swap chalk for turbocolor

### DIFF
--- a/bin/exp.js
+++ b/bin/exp.js
@@ -10,7 +10,7 @@ if (semver.satisfies(ver, '>=6.0.0')) {
   require('../build/exp.js').run('exp');
 } else {
   console.log(
-    require('chalk').red(
+    require('turbocolor').red(
       'Node version ' + ver + ' is not supported, please use Node.js 6.0 or higher.'
     )
   );

--- a/expo-cli/bin/expo.js
+++ b/expo-cli/bin/expo.js
@@ -10,7 +10,7 @@ if (semver.satisfies(ver, '>=6.0.0')) {
   require('../build/exp.js').run('expo');
 } else {
   console.log(
-    require('chalk').red(
+    require('turbocolor').red(
       'Node version ' + ver + ' is not supported, please use Node.js 6.0 or higher.'
     )
   );

--- a/expo-cli/package.json
+++ b/expo-cli/package.json
@@ -71,7 +71,7 @@
     "@expo/simple-spinner": "^1.0.2",
     "@expo/spawn-async": "^1.3.0",
     "babel-runtime": "^6.9.2",
-    "chalk": "^2.0.1",
+    "turbocolor": "^2.3.0",
     "cli-table": "^0.3.1",
     "commander": "^2.9.0",
     "delay-async": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@expo/simple-spinner": "^1.0.2",
     "@expo/spawn-async": "^1.3.0",
     "babel-runtime": "^6.9.2",
-    "chalk": "^2.0.1",
+    "turbocolor": "^2.3.0",
     "cli-table": "^0.3.1",
     "commander": "^2.9.0",
     "delay-async": "^1.0.0",

--- a/src/accounts.js
+++ b/src/accounts.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import chalk from 'chalk';
+import tc from 'turbocolor';
 
 import { User as UserManager } from 'xdl';
 import CommandError from './CommandError';
@@ -22,7 +22,7 @@ export async function loginOrRegisterIfLoggedOut() {
     return;
   }
 
-  console.log(chalk.yellow('\nAn Expo user account is required to proceed.\n'));
+  console.log(tc.yellow('\nAn Expo user account is required to proceed.\n'));
 
   const questions = [
     {
@@ -65,7 +65,7 @@ export async function login(options: CommandOptions) {
         {
           type: 'confirm',
           name: 'action',
-          message: `You are already logged in as ${chalk.green(
+          message: `You are already logged in as ${tc.green(
             user.username
           )}. Log in as new user?`,
         },
@@ -128,7 +128,7 @@ async function _usernamePasswordAuth(username?: string, password?: string): Prom
   let user = await UserManager.loginAsync('user-pass', data);
 
   if (user) {
-    console.log(`\nSuccess. You are now logged in as ${chalk.green(user.username)}.`);
+    console.log(`\nSuccess. You are now logged in as ${tc.green(user.username)}.`);
     return user;
   } else {
     throw new Error('Unexpected Error: No user returned from the API');

--- a/src/commands/build/AndroidBuilder.js
+++ b/src/commands/build/AndroidBuilder.js
@@ -6,7 +6,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import untildify from 'untildify';
 import { Exp, Credentials } from 'xdl';
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import log from '../../log';
 
 import BaseBuilder from './BaseBuilder';
@@ -38,7 +38,7 @@ export default class AndroidBuilder extends BaseBuilder {
     };
 
     log.warn(
-      `Clearing your Android build credentials from our build servers is a ${chalk.red(
+      `Clearing your Android build credentials from our build servers is a ${tc.red(
         'PERMANENT and IRREVERSIBLE action.'
       )}`
     );

--- a/src/commands/build/BaseBuilder.js
+++ b/src/commands/build/BaseBuilder.js
@@ -3,7 +3,7 @@
  */
 
 import { Project, ProjectUtils, Versions } from 'xdl';
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import fp from 'lodash/fp';
 import simpleSpinner from '@expo/simple-spinner';
 
@@ -238,7 +238,7 @@ ${buildStatus.id}
     log('Build started, it may take a few minutes to complete.');
 
     if (buildId) {
-      log(`You can monitor the build at\n\n ${chalk.underline(constructBuildLogsUrl(buildId))}\n`);
+      log(`You can monitor the build at\n\n ${tc.underline(constructBuildLogsUrl(buildId))}\n`);
     }
 
     if (this.options.wait) {
@@ -248,7 +248,7 @@ ${buildStatus.id}
       const artifactUrl = completedJob.artifactId
         ? constructArtifactUrl(completedJob.artifactId)
         : completedJob.artifacts.url;
-      log(`${chalk.green('Successfully built standalone app:')} ${chalk.underline(artifactUrl)}`);
+      log(`${tc.green('Successfully built standalone app:')} ${tc.underline(artifactUrl)}`);
     } else {
       log('Alternatively, run `exp build:status` to monitor it from the command line.');
     }
@@ -259,7 +259,7 @@ ${buildStatus.id}
     if (!isSupported) {
       const storeName = platform === 'ios' ? 'Apple App Store' : 'Google Play Store';
       log.error(
-        chalk.red(
+        tc.red(
           `Unsupported SDK version: our app builders don't have support for ${sdkVersion} version yet. Submitting the app to the ${storeName} may result in an unexpected behaviour`
         )
       );

--- a/src/commands/diagnostics.js
+++ b/src/commands/diagnostics.js
@@ -1,6 +1,6 @@
 import { Diagnostics } from 'xdl';
 import { print as envinfoPrint } from 'envinfo';
-import chalk from 'chalk';
+import tc from 'turbocolor';
 
 import simpleSpinner from '@expo/simple-spinner';
 
@@ -12,7 +12,7 @@ async function action(options) {
 
   envinfoPrint({ packages: ['expo', 'react', 'react-native'] });
 
-  console.log(chalk.underline('Diagnostics report:'));
+  console.log(tc.underline('Diagnostics report:'));
   simpleSpinner.start();
   const { url } = await Diagnostics.getDeviceInfoAsync({
     uploadLogs: true,

--- a/src/commands/fetch.js
+++ b/src/commands/fetch.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import fs from 'fs';
 import path from 'path';
 import { Credentials, Exp } from 'xdl';
@@ -87,8 +87,8 @@ export default (program: any) => {
         }
         log(`Save these important values as well:
 
-Distribution p12 password: ${chalk.bold(certPassword)}
-Push p12 password:         ${chalk.bold(pushPassword)}
+Distribution p12 password: ${tc.bold(certPassword)}
+Push p12 password:         ${tc.bold(pushPassword)}
 `);
       } catch (e) {
         throw new Error('Unable to fetch credentials for this project. Are you sure they exist?');

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import ProgressBar from 'progress';
 import { Api, Exp, Logger, NotificationCode, MessageCode } from 'xdl';
 import wordwrap from 'wordwrap';
@@ -49,7 +49,7 @@ async function action(projectDir, options) {
       message: 'Choose a template:',
       choices: versions.templatesv2.map(template => ({
         value: template.id,
-        name: chalk.bold(template.id) + '\n' + wrap(template.description),
+        name: tc.bold(template.id) + '\n' + wrap(template.description),
         short: template.id,
       })),
     }));

--- a/src/commands/publish.js
+++ b/src/commands/publish.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import simpleSpinner from '@expo/simple-spinner';
 
 import { Project } from 'xdl';
@@ -63,7 +63,7 @@ export async function action(projectDir: string, options: Options = {}) {
   }
 
   log('Published');
-  log('Your URL is\n\n' + chalk.underline(url) + '\n');
+  log('Your URL is\n\n' + tc.underline(url) + '\n');
   log.raw(url);
 
   if (recipient) {

--- a/src/commands/send.js
+++ b/src/commands/send.js
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import tc from 'turbocolor';
 
 import { UserSettings, UrlUtils } from 'xdl';
 
@@ -12,7 +12,7 @@ async function action(projectDir, options) {
 
   let url = await UrlUtils.constructManifestUrlAsync(projectDir);
 
-  log('Your URL is\n\n' + chalk.underline(url) + '\n');
+  log('Your URL is\n\n' + tc.underline(url) + '\n');
   log.raw(url);
 
   let shouldQuit = false;

--- a/src/commands/url.js
+++ b/src/commands/url.js
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import fp from 'lodash/fp';
 
 import { Project, UrlUtils } from 'xdl';
@@ -36,7 +36,7 @@ async function action(projectDir, options) {
 
   urlOpts.printQRCode(url);
 
-  log('Your URL is\n\n' + chalk.underline(url) + '\n');
+  log('Your URL is\n\n' + tc.underline(url) + '\n');
   log.raw(url);
 
   await printRunInstructionsAsync();

--- a/src/commands/whoami.js
+++ b/src/commands/whoami.js
@@ -5,12 +5,12 @@
 import { User } from 'xdl';
 
 import log from '../log';
-import chalk from 'chalk';
+import tc from 'turbocolor';
 
 async function action(options) {
   const user = await User.ensureLoggedInAsync();
   if (user && user.username) {
-    log(`Logged in as ${chalk.green(user.username)}`);
+    log(`Logged in as ${tc.green(user.username)}`);
     log.raw(user.username);
     return user;
   } else {

--- a/src/exit.js
+++ b/src/exit.js
@@ -1,6 +1,6 @@
 // @flow
 
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import { Project } from 'xdl';
 
 export function installExitHooks(projectDir: string) {
@@ -17,9 +17,9 @@ export function installExitHooks(projectDir: string) {
   }
 
   process.on('SIGINT', () => {
-    console.log(chalk.blue('\nStopping packager...'));
+    console.log(tc.blue('\nStopping packager...'));
     Project.stopAsync(projectDir).then(() => {
-      console.log(chalk.green('Packager stopped.'));
+      console.log(tc.green('Packager stopped.'));
       process.exit();
     });
   });

--- a/src/exp.js
+++ b/src/exp.js
@@ -5,7 +5,7 @@
 import ProgressBar from 'progress';
 import _ from 'lodash';
 import bunyan from '@expo/bunyan';
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import glob from 'glob';
 import fs from 'fs';
 import path from 'path';
@@ -77,16 +77,16 @@ Command.prototype.asyncAction = function(asyncFn, skipUpdateCheck) {
       if (err._isCommandError) {
         log.error(err.message);
       } else if (err._isApiError) {
-        log.error(chalk.red(err.message));
+        log.error(tc.red(err.message));
       } else if (err.isXDLError) {
         log.error(err.message);
       } else {
         log.error(err.message);
         // TODO: Is there a better way to do this? EXPO_DEBUG needs to be set to view the stack trace
         if (process.env.EXPO_DEBUG) {
-          log.error(chalk.gray(err.stack));
+          log.error(tc.gray(err.stack));
         } else {
-          log.error(chalk.grey('Set EXPO_DEBUG=true in your env to view the stack trace.'));
+          log.error(tc.gray('Set EXPO_DEBUG=true in your env to view the stack trace.'));
         }
       }
 
@@ -150,7 +150,7 @@ Command.prototype.asyncActionProjectDir = function(asyncFn, skipProjectValidatio
 
       let { message, stack } = traceInfo;
       log.addNewLineIfNone();
-      logFn(chalk.bold(message));
+      logFn(tc.bold(message));
 
       const isLibraryFrame = line => {
         return line.startsWith('node_modules');
@@ -247,9 +247,9 @@ Command.prototype.asyncActionProjectDir = function(asyncFn, skipProjectValidatio
           bar = null;
 
           if (err) {
-            log(chalk.red('Failed building JavaScript bundle.'));
+            log(tc.red('Failed building JavaScript bundle.'));
           } else {
-            log(chalk.green(`Finished building JavaScript bundle in ${endTime - startTime}ms.`));
+            log(tc.green(`Finished building JavaScript bundle in ${endTime - startTime}ms.`));
           }
         }
       },
@@ -420,7 +420,7 @@ async function checkForUpdateAsync() {
       message = `There is a new version of ${packageJSON.name} available (${latest}).
 You are currently using ${packageJSON.name} ${current}
 Run \`npm install -g ${packageJSON.name}\` to get the latest version`;
-      log.nestedWarn(chalk.green(message));
+      log.nestedWarn(tc.green(message));
       break;
 
     case 'ahead-of-published':

--- a/src/exp_commands/start.js
+++ b/src/exp_commands/start.js
@@ -4,7 +4,7 @@
 
 import { ProjectUtils, ProjectSettings, Project } from 'xdl';
 
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import path from 'path';
 
 import log from '../log';
@@ -29,7 +29,7 @@ async function action(projectDir, options) {
 
   await urlOpts.optsAsync(projectDir, options);
 
-  log(chalk.gray('Using project at', projectDir));
+  log(tc.gray(`Using project at ${projectDir}`));
 
   let root = path.resolve(projectDir);
   let startOpts = {};
@@ -54,7 +54,7 @@ async function action(projectDir, options) {
     urlOpts.printQRCode(url);
   }
 
-  log('Your URL is: ' + chalk.underline(url));
+  log('Your URL is: ' + tc.underline(url));
 
   if (!exp.isDetached) {
     await printRunInstructionsAsync();
@@ -77,7 +77,7 @@ async function action(projectDir, options) {
 
   await urlOpts.handleMobileOptsAsync(projectDir, options);
 
-  log(chalk.green('Logs for your project will appear below. Press Ctrl+C to exit.'));
+  log(tc.green('Logs for your project will appear below. Press Ctrl+C to exit.'));
 }
 
 export default (program: any) => {

--- a/src/expo_commands/eject/Eject.js
+++ b/src/expo_commands/eject/Eject.js
@@ -1,6 +1,6 @@
 // @flow
 
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import fse from 'fs-extra';
 import matchRequire from 'match-require';
 import path from 'path';
@@ -18,17 +18,17 @@ export async function ejectAsync(projectRoot: string, options) {
 
   let expoSdkWarning;
   if (usingExpo) {
-    expoSdkWarning = `${chalk.bold(
+    expoSdkWarning = `${tc.bold(
       'Warning!'
     )} We found at least one file where your project imports the Expo SDK:
 `;
 
     for (let filename of filesWithExpo) {
-      expoSdkWarning += `  ${chalk.cyan(filename)}\n`;
+      expoSdkWarning += `  ${tc.cyan(filename)}\n`;
     }
 
     expoSdkWarning += `
-${chalk.yellow.bold(
+${tc.yellow.bold(
       'If you choose the "plain" React Native option below, these imports will stop working.'
     )}`;
   } else {
@@ -40,8 +40,8 @@ We didn't find any uses of the Expo SDK in your project, so you should be fine t
   log(
     `
 ${expoSdkWarning}
-We ${chalk.italic('strongly')} recommend that you read this document before you proceed:
-  ${chalk.cyan(
+We ${tc.italic('strongly')} recommend that you read this document before you proceed:
+  ${tc.cyan(
     'https://github.com/react-community/create-react-native-app/blob/master/EJECTING.md'
   )}
 Ejecting is permanent! Please be careful with your selection.
@@ -52,7 +52,7 @@ Ejecting is permanent! Please be careful with your selection.
 
   if (usingExpo) {
     reactNativeOptionMessage =
-      chalk.italic(
+      tc.italic(
         "(WARNING: See above message for why this option may break your project's build)\n  "
       ) + reactNativeOptionMessage;
   }
@@ -130,7 +130,7 @@ Ejecting is permanent! Please be careful with your selection.
     log('Writing app.json...');
     // write the updated app.json file
     await fse.writeFile(path.resolve('app.json'), JSON.stringify(appJson, null, 2));
-    log(chalk.green('Wrote to app.json, please update it manually in the future.'));
+    log(tc.green('Wrote to app.json, please update it manually in the future.'));
     const ejectCommand = 'node';
     const ejectArgs = [
       path.resolve('node_modules', 'react-native', 'local-cli', 'cli.js'),
@@ -142,8 +142,8 @@ Ejecting is permanent! Please be careful with your selection.
     });
 
     if (status !== 0) {
-      log(chalk.red(`Eject failed with exit code ${status}, see above output for any issues.`));
-      log(chalk.yellow('You may want to delete the `ios` and/or `android` directories.'));
+      log(tc.red(`Eject failed with exit code ${status}, see above output for any issues.`));
+      log(tc.yellow('You may want to delete the `ios` and/or `android` directories.'));
       process.exit(1);
     } else {
       log('Successfully copied template native code.');
@@ -172,7 +172,7 @@ Ejecting is permanent! Please be careful with your selection.
           await fse.writeFile(projectBabelPath, JSON.stringify(babelRcJson, null, 2));
           newDevDependencies.push('babel-preset-react-native-stage-0');
           log(
-            chalk.green(
+            tc.green(
               `Babel preset changed to \`babel-preset-react-native-stage-0/decorator-support\`.`
             )
           );
@@ -180,13 +180,13 @@ Ejecting is permanent! Please be careful with your selection.
       }
     } catch (e) {
       log(
-        chalk.yellow(
+        tc.yellow(
           `We had an issue preparing your .babelrc for ejection.
 If you have a .babelrc in your project, make sure to change the preset
 from \`babel-preset-expo\` to \`babel-preset-react-native-stage-0/decorator-support\`.`
         )
       );
-      log(chalk.red(e));
+      log(tc.red(e));
     }
 
     delete pkgJson.main;
@@ -211,7 +211,7 @@ from \`babel-preset-expo\` to \`babel-preset-react-native-stage-0/decorator-supp
       newDevDependencies.push('jest-react-native');
     } else if (pkgJson.jest) {
       log(
-        `${chalk.bold(
+        `${tc.bold(
           'Warning'
         )}: it looks like you've changed the Jest preset from jest-expo to ${pkgJson.jest
           .preset}. We recommend you make sure this Jest preset is compatible with ejected apps.`
@@ -225,7 +225,7 @@ from \`babel-preset-expo\` to \`babel-preset-react-native-stage-0/decorator-supp
 
     await fse.writeFile(path.resolve('package.json'), JSON.stringify(pkgJson, null, 2));
 
-    log(chalk.green('Your package.json is up to date!'));
+    log(tc.green('Your package.json is up to date!'));
 
     // Starting from react-native 0.49.x (SDK 22), react-native eject template includes this out of the box.
     if (!Versions.gteSdkVersion(exp, '22.0.0')) {
@@ -235,7 +235,7 @@ import App from './App';
 AppRegistry.registerComponent('${appJson.name}', () => App);
 `;
       await fse.writeFile(path.resolve('index.js'), lolThatsSomeComplexCode);
-      log(chalk.green('Added new entry points!'));
+      log(tc.green('Added new entry points!'));
     }
 
     log(`
@@ -276,9 +276,9 @@ Android Studio to build the native code for your project.`);
   }
 
   log(
-    `${chalk.green('Ejected successfully!')}
+    `${tc.green('Ejected successfully!')}
 Please consider letting us know why you ejected in this survey:
-  ${chalk.cyan('https://goo.gl/forms/iD6pl218r7fn9N0d2')}`
+  ${tc.cyan('https://goo.gl/forms/iD6pl218r7fn9N0d2')}`
   );
 }
 

--- a/src/expo_commands/start.js
+++ b/src/expo_commands/start.js
@@ -4,7 +4,7 @@
 
 import { DevToolsServer } from '@expo/dev-tools';
 import { ProjectUtils, ProjectSettings, Project, UserSettings, UrlUtils } from 'xdl';
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import opn from 'opn';
 import path from 'path';
 
@@ -27,7 +27,7 @@ async function action(projectDir, options) {
 
   await urlOpts.optsAsync(projectDir, options);
 
-  log(chalk.gray('Starting project at', projectDir));
+  log(tc.gray(`Starting project at ${projectDir}`));
 
   let root = path.resolve(projectDir);
   let startOpts = {};
@@ -53,14 +53,14 @@ async function action(projectDir, options) {
 
   const { exp } = await ProjectUtils.readConfigJsonAsync(projectDir);
 
-  log(`Expo DevTools is running at ${chalk.underline(devToolsUrl)}`);
+  log(`Expo DevTools is running at ${tc.underline(devToolsUrl)}`);
   if (!options.nonInteractive && !exp.isDetached) {
     if (await UserSettings.getAsync('openDevToolsAtStartup', true)) {
-      log(`Opening DevTools in the browser... (press ${chalk.bold`shift-d`} to disable)`);
+      log(`Opening DevTools in the browser... (press ${tc.bold('shift-d')} to disable)`);
       opn(devToolsUrl);
     } else {
       log(
-        `Press ${chalk.bold`d`} to open DevTools now, or ${chalk.bold`shift-d`} to always open it automatically.`
+        `Press ${tc.bold('d')} to open DevTools now, or ${tc.bold('shift-d')} to always open it automatically.`
       );
     }
     await TerminalUI.startAsync(projectDir);
@@ -69,10 +69,10 @@ async function action(projectDir, options) {
       log.newLine();
       urlOpts.printQRCode(url);
     }
-    log(`Your app is running at ${chalk.underline(url)}`);
+    log(`Your app is running at ${tc.underline(url)}`);
   }
 
-  log.nested(chalk.green('Logs for your project will appear below. Press Ctrl+C to exit.'));
+  log.nested(tc.green('Logs for your project will appear below. Press Ctrl+C to exit.'));
 }
 
 export default (program: any) => {

--- a/src/expo_commands/start/TerminalUI.js
+++ b/src/expo_commands/start/TerminalUI.js
@@ -12,7 +12,7 @@ import {
   UserSettings,
 } from 'xdl';
 
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import opn from 'opn';
 import readline from 'readline';
 import wordwrap from 'wordwrap';
@@ -25,7 +25,7 @@ const CTRL_C = '\u0003';
 const CTRL_D = '\u0004';
 const CTRL_L = '\u000C';
 
-const { bold: b, italic: i, underline: u } = chalk;
+const { bold: b, italic: i, underline: u } = tc;
 
 const clearConsole = () => {
   process.stdout.write(process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H');
@@ -221,9 +221,9 @@ export const startAsync = async projectDir => {
         const dev = !projectSettings.dev;
         await ProjectSettings.setAsync(projectDir, { dev, minify: !dev });
         log(
-          `Metro Bundler is now running in ${chalk.bold(
+          `Metro Bundler is now running in ${tc.bold(
             dev ? 'development' : 'production'
-          )}${chalk.reset(` mode.`)}
+          )}${tc.reset(` mode.`)}
 Please reload the project in the Expo app for the change to take effect.`
         );
         printHelp();

--- a/src/log.js
+++ b/src/log.js
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import tc from 'turbocolor';
 
 let _bundleProgressBar;
 
@@ -56,16 +56,16 @@ function respectProgressBars(commitLogs) {
   }
 }
 
-function getPrefix(chalkColor) {
-  return chalkColor(`[${new Date().toTimeString().slice(0, 8)}]`);
+function getPrefix(color) {
+  return color(`[${new Date().toTimeString().slice(0, 8)}]`);
 }
 
-function withPrefixAndTextColor(args, chalkColor = chalk.gray) {
-  return [getPrefix(chalkColor), ...args.map(arg => chalkColor(arg))];
+function withPrefixAndTextColor(args, color = tc.gray) {
+  return [getPrefix(color), ...args.map(arg => color(arg))];
 }
 
-function withPrefix(args, chalkColor = chalk.gray) {
-  return [getPrefix(chalkColor), ...args];
+function withPrefix(args, color = tc.gray) {
+  return [getPrefix(color), ...args];
 }
 
 function log(...args) {
@@ -110,13 +110,13 @@ log.error = function error(...args) {
   }
 
   respectProgressBars(() => {
-    consoleError(...withPrefixAndTextColor(args, chalk.red));
+    consoleError(...withPrefixAndTextColor(args, tc.red));
   });
 };
 
 log.nestedError = function(message) {
   respectProgressBars(() => {
-    consoleError(chalk.red(message));
+    consoleError(tc.red(message));
   });
 };
 
@@ -126,13 +126,13 @@ log.warn = function warn(...args) {
   }
 
   respectProgressBars(() => {
-    consoleWarn(...withPrefixAndTextColor(args, chalk.yellow));
+    consoleWarn(...withPrefixAndTextColor(args, tc.yellow));
   });
 };
 
 log.nestedWarn = function(message) {
   respectProgressBars(() => {
-    consoleWarn(chalk.yellow(message));
+    consoleWarn(tc.yellow(message));
   });
 };
 
@@ -156,7 +156,7 @@ log.raw = function(...args) {
   });
 };
 
-log.chalk = chalk;
+log.tc = tc;
 
 log.config = {
   raw: false,

--- a/src/printRunInstructionsAsync.js
+++ b/src/printRunInstructionsAsync.js
@@ -1,5 +1,5 @@
 import { User as UserManager } from 'xdl';
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import log from './log';
 
 export default async function printRunInstructionsAsync() {
@@ -8,26 +8,26 @@ export default async function printRunInstructionsAsync() {
   // If no user, we are offline and can't connect
   if (user) {
     log.newLine();
-    log(chalk.bold('Instructions to open this project on a physical device'));
-    log(`${chalk.underline('Android devices')}: scan the above QR code.`);
+    log(tc.bold('Instructions to open this project on a physical device'));
+    log(`${tc.underline('Android devices')}: scan the above QR code.`);
     log(
-      `${chalk.underline('iOS devices')}: run ${chalk.bold(
+      `${tc.underline('iOS devices')}: run ${tc.bold(
         'exp send -s <your-phone-number-or-email>'
       )} in this project directory in another terminal window to send the URL to your device.`
     );
 
     // NOTE(brentvatne) Uncomment this when we update iOS client
     // log(
-    //   `Alternatively, sign in to your account (${chalk.bold(
+    //   `Alternatively, sign in to your account (${tc.bold(
     //     user.username
     //   )}) in the latest version of the Expo client on your iOS or Android device. Your projects will automatically appear in the "Projects" tab.`
     // );
   }
 
   log.newLine();
-  log(chalk.bold('Instructions to open this project on a simulator'));
+  log(tc.bold('Instructions to open this project on a simulator'));
   log(
-    `If you already have the simulator installed, run ${chalk.bold('exp ios')} or ${chalk.bold(
+    `If you already have the simulator installed, run ${tc.bold('exp ios')} or ${tc.bold(
       'exp android'
     )} in this project directory in another terminal window.`
   );


### PR DESCRIPTION
Hello @fson, @jesseruder and maintainers! 👋 

This is a PR for your consideration that swaps chalk for [turbocolor](https://github.com/jorgebucaran/turbocolor).

It ought to give you a perf boost as turbocolor loads **_>20x_** faster and applies styles **_>18x_** faster than chalk for essentially the same API. Let me know if this looks good to you and if you'd like to accept my contribution.

<pre>
# Load Time
chalk: 15.190ms
<b>turbocolor: 0.777ms</b>

# All Colors
chalk × 8,729 ops/sec
<b>turbocolor × 158,383 ops/sec</b>

# Chained Colors
chalk × 1,838 ops/sec
<b>turbocolor × 39,830 ops/sec</b>

# Nested Colors
chalk × 4,049 ops/sec
<b>turbocolor × 59,833 ops/sec</b>
</pre>

You can find more about the benchmarks [here](https://github.com/jorgebucaran/turbocolor/tree/master/bench#benchmarks). Cheers!