### PR TITLE
[issue]OBLIGATORY_CREDS_KEYS.keys is not a function

### DIFF
--- a/src/commands/build/IOSBuilder.js
+++ b/src/commands/build/IOSBuilder.js
@@ -583,7 +583,7 @@ See https://docs.expo.io/versions/latest/guides/building-standalone-apps.html`
       await this.runningAsCI(credsStarter, credsMetadata);
       this._areCredsMissing(credsStarter);
       await Credentials.updateCredentialsForPlatform('ios', credsStarter, credsMetadata);
-      log.warn(`Encrypted ${[...Object.keys(OBLIGATORY_CREDS_KEYS)]} and saved to expo servers`);
+      log.warn(`Encrypted ${Object.keys(OBLIGATORY_CREDS_KEYS)} and saved to expo servers`);
     } else if (clientHasAllNeededCreds === false) {
       // We just keep mutating the creds object.
       const strategy = await prompt(runAsExpertQuestion);

--- a/src/commands/build/IOSBuilder.js
+++ b/src/commands/build/IOSBuilder.js
@@ -583,7 +583,7 @@ See https://docs.expo.io/versions/latest/guides/building-standalone-apps.html`
       await this.runningAsCI(credsStarter, credsMetadata);
       this._areCredsMissing(credsStarter);
       await Credentials.updateCredentialsForPlatform('ios', credsStarter, credsMetadata);
-      log.warn(`Encrypted ${[...OBLIGATORY_CREDS_KEYS.keys()]} and saved to expo servers`);
+      log.warn(`Encrypted ${[...Object.keys(OBLIGATORY_CREDS_KEYS)]} and saved to expo servers`);
     } else if (clientHasAllNeededCreds === false) {
       // We just keep mutating the creds object.
       const strategy = await prompt(runAsExpertQuestion);


### PR DESCRIPTION
Please check this Issue 
https://github.com/expo/expo/issues/2014
```bash
 henry@hmp  ~/work/st/dev  node
> const OBLIGATORY_CREDS_KEYS = {
...   pushP12: 'pushCert',
...   pushPassword: 'pushCert',
...   provisioningProfile: 'provisioningProfile',
...   teamId: 'teamId',
... };
undefined
> OBLIGATORY_CREDS_KEYS.keys()
TypeError: OBLIGATORY_CREDS_KEYS.keys is not a function
> Object.keys(OBLIGATORY_CREDS_KEYS)
[ 'pushP12', 'pushPassword', 'provisioningProfile', 'teamId' ]
>
```