### PR TITLE
Update installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ at https://github.com/expo/expo. Thanks!
 
 ## Installation
 
-[Installation instructions and documentation here.](https://docs.expo.io/versions/latest/guides/exp-cli.html)
+[Installation instructions and documentation here.](https://docs.expo.io/versions/latest/introduction/installation)
 
 ## Getting Started
 


### PR DESCRIPTION
I noticed the installation link was broken. The proposed fix seems to address the issue, but if there is a preferred approach, let me know.